### PR TITLE
feat: add i18n module with locale files for 4 languages

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,92 @@
+// i18n 모듈 - 다국어 지원 (영어, 한국어, 일본어, 중국어)
+
+import { DEFAULT_LANGUAGE, STORAGE_KEY_LANGUAGE } from '../constants';
+import { getStorage, setStorage } from '../utils/storage.util';
+import type { Language } from '../types/storage.types';
+
+import en from './locales/en.json';
+import ko from './locales/ko.json';
+import ja from './locales/ja.json';
+import zh from './locales/zh.json';
+
+// ── 로케일 맵 ──────────────────────────────────────────────
+
+const LOCALES: Record<Language, typeof en> = { en, ko, ja, zh };
+
+// ── 현재 언어 상태 ─────────────────────────────────────────
+
+let currentLanguage: Language = DEFAULT_LANGUAGE;
+
+// ── 초기화 ─────────────────────────────────────────────────
+
+/**
+ * storage에서 저장된 언어를 로드하여 현재 언어로 설정
+ * 페이지 진입 시 최초 1회 호출
+ */
+export async function initI18n(): Promise<void> {
+  const saved = await getStorage(STORAGE_KEY_LANGUAGE);
+  if (saved && saved in LOCALES) {
+    currentLanguage = saved;
+  }
+}
+
+// ── 번역 함수 ──────────────────────────────────────────────
+
+type LocaleData = typeof en;
+type LocaleSection = keyof LocaleData;
+type LocaleKey<S extends LocaleSection> = keyof LocaleData[S];
+
+/**
+ * 번역 키로 현재 언어의 문자열을 반환
+ * 변수 치환 지원: {{count}} 형태
+ *
+ * @example t('popup', 'sortPopularity') → "Popularity"
+ * @example t('popup', 'showReplies', { count: 5 }) → "5 Replies"
+ */
+export function t<S extends LocaleSection>(
+  section: S,
+  key: LocaleKey<S>,
+  variables?: Record<string, string | number>,
+): string {
+  const locale = LOCALES[currentLanguage] ?? LOCALES[DEFAULT_LANGUAGE];
+  const sectionData = locale[section] as Record<string, string>;
+  let text = sectionData[key as string] ?? String(key);
+
+  if (variables) {
+    Object.entries(variables).forEach(([varKey, value]) => {
+      text = text.replace(new RegExp(`{{${varKey}}}`, 'g'), String(value));
+    });
+  }
+
+  return text;
+}
+
+// ── 언어 변경 ──────────────────────────────────────────────
+
+/**
+ * 언어를 변경하고 storage에 저장
+ */
+export async function setLanguage(language: Language): Promise<void> {
+  currentLanguage = language;
+  await setStorage({ [STORAGE_KEY_LANGUAGE]: language });
+}
+
+/**
+ * 현재 언어 반환
+ */
+export function getCurrentLanguage(): Language {
+  return currentLanguage;
+}
+
+/**
+ * 지원 언어 목록 반환 (드롭다운 렌더링용)
+ * 순서: English → 한국어 → 日本語 → 中文
+ */
+export function getSupportedLanguages(): { code: Language; label: string }[] {
+  return [
+    { code: 'en', label: 'English' },
+    { code: 'ko', label: '한국어' },
+    { code: 'ja', label: '日本語' },
+    { code: 'zh', label: '中文' },
+  ];
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,43 @@
+{
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "ko": "한국어",
+    "ja": "日本語",
+    "zh": "中文"
+  },
+  "options": {
+    "title": "YouTube Timestamp Comments",
+    "subtitle": "Enhance your viewing experience with timestamped notes.",
+    "apiKeyLabel": "API Key",
+    "apiKeyPlaceholder": "Enter your API Key here",
+    "setupButton": "Set up",
+    "guideText": "Need help finding your API Key?",
+    "guideLink": "Read the guide",
+    "savedMessage": "API Key saved successfully!",
+    "errorEmptyKey": "Please enter an API Key."
+  },
+  "popup": {
+    "commentCount": "Comment",
+    "more": "more",
+    "sortBy": "Sort by",
+    "sortPopularity": "Popularity",
+    "sortLatest": "Latest",
+    "searchByTimestamp": "Search by timestamp",
+    "settings": "Settings",
+    "replies": "Replies",
+    "reply": "Reply",
+    "showReplies": "{{count}} Replies",
+    "hideReplies": "Hide Replies",
+    "noComments": "No timestamped comments found.",
+    "loading": "Loading comments...",
+    "errorNoVideo": "No YouTube video detected.",
+    "errorNoApiKey": "API Key is not set. Please go to Settings.",
+    "errorFetch": "Failed to fetch comments. Please try again."
+  },
+  "modal": {
+    "title": "Please enter a timestamp",
+    "searchButton": "Search",
+    "rangeLabel": "±"
+  }
+}

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1,0 +1,43 @@
+{
+  "language": {
+    "label": "言語",
+    "en": "English",
+    "ko": "한국어",
+    "ja": "日本語",
+    "zh": "中文"
+  },
+  "options": {
+    "title": "YouTube Timestamp Comments",
+    "subtitle": "タイムスタンプ付きのコメントで視聴体験を向上させましょう。",
+    "apiKeyLabel": "APIキー",
+    "apiKeyPlaceholder": "APIキーを入力してください",
+    "setupButton": "設定完了",
+    "guideText": "APIキーの取得方法がわからない場合は",
+    "guideLink": "ガイドを読む",
+    "savedMessage": "APIキーが保存されました！",
+    "errorEmptyKey": "APIキーを入力してください。"
+  },
+  "popup": {
+    "commentCount": "コメント",
+    "more": "もっと見る",
+    "sortBy": "並び替え",
+    "sortPopularity": "人気順",
+    "sortLatest": "新着順",
+    "searchByTimestamp": "タイムスタンプで検索",
+    "settings": "設定",
+    "replies": "返信",
+    "reply": "返信",
+    "showReplies": "返信 {{count}}件",
+    "hideReplies": "返信を隠す",
+    "noComments": "タイムスタンプを含むコメントが見つかりません。",
+    "loading": "コメントを読み込み中...",
+    "errorNoVideo": "YouTube動画が検出されませんでした。",
+    "errorNoApiKey": "APIキーが設定されていません。設定に移動してください。",
+    "errorFetch": "コメントの取得に失敗しました。もう一度お試しください。"
+  },
+  "modal": {
+    "title": "タイムスタンプを入力してください",
+    "searchButton": "検索",
+    "rangeLabel": "±"
+  }
+}

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1,0 +1,43 @@
+{
+  "language": {
+    "label": "언어",
+    "en": "English",
+    "ko": "한국어",
+    "ja": "日本語",
+    "zh": "中文"
+  },
+  "options": {
+    "title": "YouTube Timestamp Comments",
+    "subtitle": "타임스탬프 기반 노트로 시청 경험을 향상시키세요.",
+    "apiKeyLabel": "API 키",
+    "apiKeyPlaceholder": "API 키를 입력하세요",
+    "setupButton": "설정 완료",
+    "guideText": "API Key를 찾는 데 도움이 필요하신가요?",
+    "guideLink": "가이드 보기",
+    "savedMessage": "API 키가 저장되었습니다!",
+    "errorEmptyKey": "API 키를 입력해주세요."
+  },
+  "popup": {
+    "commentCount": "댓글",
+    "more": "더보기",
+    "sortBy": "정렬",
+    "sortPopularity": "인기순",
+    "sortLatest": "최신순",
+    "searchByTimestamp": "타임스탬프로 검색",
+    "settings": "설정",
+    "replies": "답글",
+    "reply": "답글",
+    "showReplies": "답글 {{count}}개",
+    "hideReplies": "답글 숨기기",
+    "noComments": "타임스탬프가 포함된 댓글이 없습니다.",
+    "loading": "댓글을 불러오는 중...",
+    "errorNoVideo": "YouTube 동영상을 감지하지 못했습니다.",
+    "errorNoApiKey": "API 키가 설정되지 않았습니다. 설정으로 이동해주세요.",
+    "errorFetch": "댓글을 불러오지 못했습니다. 다시 시도해주세요."
+  },
+  "modal": {
+    "title": "타임스탬프를 입력하세요",
+    "searchButton": "검색",
+    "rangeLabel": "±"
+  }
+}

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1,0 +1,43 @@
+{
+  "language": {
+    "label": "语言",
+    "en": "English",
+    "ko": "한국어",
+    "ja": "日本語",
+    "zh": "中文"
+  },
+  "options": {
+    "title": "YouTube Timestamp Comments",
+    "subtitle": "通过带时间戳的评论提升您的观看体验。",
+    "apiKeyLabel": "API 密钥",
+    "apiKeyPlaceholder": "请输入您的 API 密钥",
+    "setupButton": "完成设置",
+    "guideText": "不知道如何获取 API 密钥？",
+    "guideLink": "查看指南",
+    "savedMessage": "API 密钥已成功保存！",
+    "errorEmptyKey": "请输入 API 密钥。"
+  },
+  "popup": {
+    "commentCount": "评论",
+    "more": "更多",
+    "sortBy": "排序",
+    "sortPopularity": "热门",
+    "sortLatest": "最新",
+    "searchByTimestamp": "按时间戳搜索",
+    "settings": "设置",
+    "replies": "回复",
+    "reply": "回复",
+    "showReplies": "{{count}} 条回复",
+    "hideReplies": "隐藏回复",
+    "noComments": "未找到包含时间戳的评论。",
+    "loading": "正在加载评论...",
+    "errorNoVideo": "未检测到 YouTube 视频。",
+    "errorNoApiKey": "未设置 API 密钥，请前往设置。",
+    "errorFetch": "获取评论失败，请重试。"
+  },
+  "modal": {
+    "title": "请输入时间戳",
+    "searchButton": "搜索",
+    "rangeLabel": "±"
+  }
+}


### PR DESCRIPTION
Issue #8 
- Add locale JSON files (en, ko, ja, zh) with options/popup/modal keys
- Add initI18n() to load saved language from storage on page load
- Add t() as type-safe translation function with variable interpolation
- Add setLanguage() to persist language change to storage
- Add getSupportedLanguages() for dropdown rendering