### PR TITLE
feat: implement Background Service Worker and Content Script

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,9 +4,7 @@
 import { fetchCommentThreads, fetchReplies, YouTubeApiError } from '../services/youtube.service';
 import { getStorage } from '../utils/storage.util';
 import { STORAGE_KEY_API_KEY } from '../constants';
-import {
-  MessageType,
-} from '../types/message.types';
+import { MessageType } from '../types/message.types';
 import type {
   RequestMessage,
   FetchCommentsRequest,
@@ -42,9 +40,31 @@ async function handleMessage(
       break;
 
     case MessageType.GET_VIDEO_ID:
-      // Content Script에서 직접 처리하므로 Background에서는 미사용
+      // Popup → Content Script 직접 쿼리 방식으로 처리하므로
+      // Background에서는 포트 에러 방지를 위해 빈 응답만 반환
+      sendResponse({
+        type: MessageType.GET_VIDEO_ID,
+        payload: { videoId: null },
+      });
       break;
+
+    default:
+      sendResponse({
+        type: MessageType.ERROR,
+        error: 'Unknown message type.',
+      });
   }
+}
+
+// ── API 키 조회 헬퍼 ───────────────────────────────────────
+
+/**
+ * chrome.storage.local에서 API 키를 읽어 반환
+ * API 키가 없으면 null 반환
+ */
+async function getApiKey(): Promise<string | null> {
+  const apiKey = await getStorage(STORAGE_KEY_API_KEY);
+  return apiKey ?? null;
 }
 
 // ── FETCH_COMMENTS 처리 ────────────────────────────────────
@@ -54,7 +74,7 @@ async function handleFetchComments(
   sendResponse: (response: ResponseMessage) => void,
 ): Promise<void> {
   try {
-    const apiKey = await getStorage(STORAGE_KEY_API_KEY);
+    const apiKey = await getApiKey();
 
     if (!apiKey) {
       sendResponse({
@@ -87,7 +107,7 @@ async function handleFetchReplies(
   sendResponse: (response: ResponseMessage) => void,
 ): Promise<void> {
   try {
-    const apiKey = await getStorage(STORAGE_KEY_API_KEY);
+    const apiKey = await getApiKey();
 
     if (!apiKey) {
       sendResponse({

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,2 +1,129 @@
-// Background Service Worker - Step 7에서 구현 예정
-export {};
+// Background Service Worker
+// API 키를 chrome.storage.local에서 읽어 YouTube API 호출을 대리 처리한다.
+
+import { fetchCommentThreads, fetchReplies, YouTubeApiError } from '../services/youtube.service';
+import { getStorage } from '../utils/storage.util';
+import { STORAGE_KEY_API_KEY } from '../constants';
+import {
+  MessageType,
+} from '../types/message.types';
+import type {
+  RequestMessage,
+  FetchCommentsRequest,
+  FetchRepliesRequest,
+  ResponseMessage,
+} from '../types/message.types';
+
+// ── 메시지 핸들러 ──────────────────────────────────────────
+
+chrome.runtime.onMessage.addListener(
+  (
+    message: RequestMessage,
+    _sender: chrome.runtime.MessageSender,
+    sendResponse: (response: ResponseMessage) => void,
+  ) => {
+    void handleMessage(message, sendResponse);
+    // 비동기 응답을 위해 true 반환
+    return true;
+  },
+);
+
+async function handleMessage(
+  message: RequestMessage,
+  sendResponse: (response: ResponseMessage) => void,
+): Promise<void> {
+  switch (message.type) {
+    case MessageType.FETCH_COMMENTS:
+      await handleFetchComments(message, sendResponse);
+      break;
+
+    case MessageType.FETCH_REPLIES:
+      await handleFetchReplies(message, sendResponse);
+      break;
+
+    case MessageType.GET_VIDEO_ID:
+      // Content Script에서 직접 처리하므로 Background에서는 미사용
+      break;
+  }
+}
+
+// ── FETCH_COMMENTS 처리 ────────────────────────────────────
+
+async function handleFetchComments(
+  message: FetchCommentsRequest,
+  sendResponse: (response: ResponseMessage) => void,
+): Promise<void> {
+  try {
+    const apiKey = await getStorage(STORAGE_KEY_API_KEY);
+
+    if (!apiKey) {
+      sendResponse({
+        type: MessageType.ERROR,
+        error: 'API Key is not set. Please go to Settings.',
+        code: 401,
+      });
+      return;
+    }
+
+    const { videoId, order, pageToken } = message.payload;
+    const result = await fetchCommentThreads(videoId, apiKey, order, pageToken);
+
+    sendResponse({
+      type: MessageType.FETCH_COMMENTS,
+      payload: {
+        items: result.items,
+        nextPageToken: result.nextPageToken,
+      },
+    });
+  } catch (err) {
+    sendResponse(buildErrorResponse(err));
+  }
+}
+
+// ── FETCH_REPLIES 처리 ─────────────────────────────────────
+
+async function handleFetchReplies(
+  message: FetchRepliesRequest,
+  sendResponse: (response: ResponseMessage) => void,
+): Promise<void> {
+  try {
+    const apiKey = await getStorage(STORAGE_KEY_API_KEY);
+
+    if (!apiKey) {
+      sendResponse({
+        type: MessageType.ERROR,
+        error: 'API Key is not set. Please go to Settings.',
+        code: 401,
+      });
+      return;
+    }
+
+    const { parentId } = message.payload;
+    const result = await fetchReplies(parentId, apiKey);
+
+    sendResponse({
+      type: MessageType.FETCH_REPLIES,
+      payload: {
+        items: result.items,
+      },
+    });
+  } catch (err) {
+    sendResponse(buildErrorResponse(err));
+  }
+}
+
+// ── 에러 응답 빌더 ─────────────────────────────────────────
+
+function buildErrorResponse(err: unknown): ResponseMessage {
+  if (err instanceof YouTubeApiError) {
+    return {
+      type: MessageType.ERROR,
+      error: err.message,
+      code: err.code,
+    };
+  }
+  return {
+    type: MessageType.ERROR,
+    error: err instanceof Error ? err.message : 'An unexpected error occurred.',
+  };
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,8 +1,9 @@
 // Content Script
-// YouTube 페이지에서 현재 영상의 videoId를 추출하여 Background에 전달한다.
+// YouTube 페이지에서 현재 영상의 videoId를 추출한다.
+// Popup이 chrome.tabs.sendMessage로 GET_VIDEO_ID를 요청하면 응답한다.
 
 import { MessageType } from '../types/message.types';
-import type { GetVideoIdResponse } from '../types/message.types';
+import type { GetVideoIdRequest, GetVideoIdResponse } from '../types/message.types';
 
 // ── videoId 추출 ───────────────────────────────────────────
 
@@ -15,25 +16,22 @@ function extractVideoId(): string | null {
   return url.searchParams.get('v');
 }
 
-// ── Background로 videoId 전달 ──────────────────────────────
+// ── Popup 요청 리스너 ──────────────────────────────────────
+// Popup이 chrome.tabs.sendMessage(tabId, { type: GET_VIDEO_ID })로 요청하면
+// 현재 videoId를 응답한다.
 
-function sendVideoId(videoId: string | null): void {
-  const response: GetVideoIdResponse = {
-    type: MessageType.GET_VIDEO_ID,
-    payload: { videoId },
-  };
-  chrome.runtime.sendMessage(response);
-}
-
-// ── 초기 실행 ──────────────────────────────────────────────
-
-sendVideoId(extractVideoId());
-
-// ── YouTube SPA 네비게이션 감지 ───────────────────────────
-// YouTube는 SPA 방식으로 동작하므로 페이지 이동 시 URL은 변경되지만
-// Content Script가 재실행되지 않는다.
-// 'yt-navigate-finish' 이벤트로 영상 전환을 감지하여 videoId를 재전송한다.
-
-window.addEventListener('yt-navigate-finish', () => {
-  sendVideoId(extractVideoId());
-});
+chrome.runtime.onMessage.addListener(
+  (
+    message: GetVideoIdRequest,
+    _sender: chrome.runtime.MessageSender,
+    sendResponse: (response: GetVideoIdResponse) => void,
+  ) => {
+    if (message.type === MessageType.GET_VIDEO_ID) {
+      sendResponse({
+        type: MessageType.GET_VIDEO_ID,
+        payload: { videoId: extractVideoId() },
+      });
+    }
+    // 동기 응답이므로 true 반환 불필요
+  },
+);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,2 +1,39 @@
-// Content Script - Step 8에서 구현 예정
-export {};
+// Content Script
+// YouTube 페이지에서 현재 영상의 videoId를 추출하여 Background에 전달한다.
+
+import { MessageType } from '../types/message.types';
+import type { GetVideoIdResponse } from '../types/message.types';
+
+// ── videoId 추출 ───────────────────────────────────────────
+
+/**
+ * 현재 URL에서 YouTube videoId 파라미터를 추출
+ * @example "https://www.youtube.com/watch?v=abc123" → "abc123"
+ */
+function extractVideoId(): string | null {
+  const url = new URL(window.location.href);
+  return url.searchParams.get('v');
+}
+
+// ── Background로 videoId 전달 ──────────────────────────────
+
+function sendVideoId(videoId: string | null): void {
+  const response: GetVideoIdResponse = {
+    type: MessageType.GET_VIDEO_ID,
+    payload: { videoId },
+  };
+  chrome.runtime.sendMessage(response);
+}
+
+// ── 초기 실행 ──────────────────────────────────────────────
+
+sendVideoId(extractVideoId());
+
+// ── YouTube SPA 네비게이션 감지 ───────────────────────────
+// YouTube는 SPA 방식으로 동작하므로 페이지 이동 시 URL은 변경되지만
+// Content Script가 재실행되지 않는다.
+// 'yt-navigate-finish' 이벤트로 영상 전환을 감지하여 videoId를 재전송한다.
+
+window.addEventListener('yt-navigate-finish', () => {
+  sendVideoId(extractVideoId());
+});


### PR DESCRIPTION
Issue #12 
- Add message listener in background to proxy YouTube API calls
- Read API key from chrome.storage.local (never exposed to Popup)
- Handle FETCH_COMMENTS and FETCH_REPLIES with error responses
- Extract videoId from URL in content script
- Detect YouTube SPA navigation via yt-navigate-finish event