### PR TITLE
feat: implement Options page with API key setup and settings

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -7,17 +7,29 @@ import { getStorage, setStorage } from '../utils/storage.util';
 import { STORAGE_KEY_API_KEY, STORAGE_KEY_THEME, THEME_DARK, THEME_LIGHT } from '../constants';
 import type { Language } from '../types/storage.types';
 
+// ── DOM 헬퍼 ───────────────────────────────────────────────
+
+/**
+ * getElementById 래퍼 — 요소가 없으면 초기화 시점에 즉시 throw
+ * HTML 구조 변경 시 런타임 에러를 빠르게 발견할 수 있다.
+ */
+function getElement<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Element with id '${id}' not found.`);
+  return el as T;
+}
+
 // ── DOM 참조 ───────────────────────────────────────────────
 
-const apiKeyInput    = document.getElementById('api-key')        as HTMLInputElement;
-const setupBtn       = document.getElementById('setup-btn')      as HTMLButtonElement;
-const visibilityBtn  = document.getElementById('visibility-btn') as HTMLButtonElement;
-const eyeIcon        = document.getElementById('eye-icon')       as HTMLSpanElement;
-const saveMessage    = document.getElementById('save-message')   as HTMLParagraphElement;
-const themeToggleBtn = document.getElementById('theme-toggle')   as HTMLButtonElement;
-const langBtn        = document.getElementById('lang-btn')       as HTMLButtonElement;
-const langMenu       = document.getElementById('lang-menu')      as HTMLDivElement;
-const langLabel      = document.getElementById('lang-label')     as HTMLSpanElement;
+const apiKeyInput    = getElement<HTMLInputElement>('api-key');
+const setupBtn       = getElement<HTMLButtonElement>('setup-btn');
+const visibilityBtn  = getElement<HTMLButtonElement>('visibility-btn');
+const eyeIcon        = getElement<HTMLSpanElement>('eye-icon');
+const saveMessage    = getElement<HTMLParagraphElement>('save-message');
+const themeToggleBtn = getElement<HTMLButtonElement>('theme-toggle');
+const langBtn        = getElement<HTMLButtonElement>('lang-btn');
+const langMenu       = getElement<HTMLDivElement>('lang-menu');
+const langLabel      = getElement<HTMLSpanElement>('lang-label');
 
 // ── 다크모드 ───────────────────────────────────────────────
 
@@ -43,10 +55,13 @@ function toggleVisibility(): void {
 
 // ── 저장 메시지 표시 ───────────────────────────────────────
 
+let saveMessageTimeoutId: number;
+
 function showSaveMessage(text: string, type: 'success' | 'error'): void {
+  clearTimeout(saveMessageTimeoutId);
   saveMessage.textContent = text;
   saveMessage.className = `save-message ${type}`;
-  setTimeout(() => {
+  saveMessageTimeoutId = window.setTimeout(() => {
     saveMessage.className = 'save-message hidden';
   }, 3000);
 }
@@ -93,7 +108,6 @@ function updateActiveLangItem(): void {
   document.querySelectorAll<HTMLAnchorElement>('.lang-item').forEach((el) => {
     el.classList.toggle('active', el.dataset.lang === current);
   });
-  // 헤더 언어 버튼 레이블 업데이트
   const langs = getSupportedLanguages();
   const found = langs.find((l) => l.code === current);
   if (found) langLabel.textContent = found.label;
@@ -101,30 +115,37 @@ function updateActiveLangItem(): void {
 
 // ── i18n 적용 ──────────────────────────────────────────────
 
-function applyI18n(): void {
-  // data-i18n 속성을 가진 요소 텍스트 교체
-  document.querySelectorAll<HTMLElement>('[data-i18n]').forEach((el) => {
-    const key = el.dataset.i18n ?? '';
-    const [section, k] = key.split('.') as [string, string];
+function applyI18nToElements(
+  selector: string,
+  apply: (el: HTMLElement, text: string) => void,
+  dataKey: string,
+): void {
+  document.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+    const key = (el.dataset[dataKey] ?? '');
+    const [section, k] = key.split('.');
+    if (!section || !k) return;
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      el.textContent = t(section as any, k as any);
+      apply(el, t(section as any, k as any));
     } catch {
       // 키가 없으면 그대로 유지
     }
   });
+}
 
-  // data-i18n-placeholder 속성을 가진 input placeholder 교체
-  document.querySelectorAll<HTMLInputElement>('[data-i18n-placeholder]').forEach((el) => {
-    const key = el.dataset.i18nPlaceholder ?? '';
-    const [section, k] = key.split('.') as [string, string];
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      el.placeholder = t(section as any, k as any);
-    } catch {
-      // 키가 없으면 그대로 유지
-    }
-  });
+function applyI18n(): void {
+  // html lang 속성 업데이트 (스크린 리더 접근성)
+  document.documentElement.lang = getCurrentLanguage();
+
+  // data-i18n: textContent 교체
+  applyI18nToElements('[data-i18n]', (el, text) => {
+    el.textContent = text;
+  }, 'i18n');
+
+  // data-i18n-placeholder: input placeholder 교체
+  applyI18nToElements('[data-i18n-placeholder]', (el, text) => {
+    if (el instanceof HTMLInputElement) el.placeholder = text;
+  }, 'i18nPlaceholder');
 }
 
 // ── 저장된 API 키 로드 ─────────────────────────────────────
@@ -137,25 +158,19 @@ async function loadApiKey(): Promise<void> {
 // ── 이벤트 등록 ───────────────────────────────────────────
 
 function bindEvents(): void {
-  // API 키 저장
   setupBtn.addEventListener('click', () => { void saveApiKey(); });
   apiKeyInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') void saveApiKey();
   });
 
-  // 비밀번호 가시성
   visibilityBtn.addEventListener('click', toggleVisibility);
-
-  // 다크모드
   themeToggleBtn.addEventListener('click', toggleTheme);
 
-  // 언어 드롭다운 - 버튼 클릭 토글
   langBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     toggleLangMenu();
   });
 
-  // 언어 선택
   document.querySelectorAll<HTMLAnchorElement>('.lang-item').forEach((el) => {
     el.addEventListener('click', (e) => {
       e.preventDefault();
@@ -164,7 +179,6 @@ function bindEvents(): void {
     });
   });
 
-  // 외부 클릭 시 드롭다운 닫기
   document.addEventListener('click', (e) => {
     if (!langBtn.contains(e.target as Node) && !langMenu.contains(e.target as Node)) {
       closeLangMenu();

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -1,2 +1,186 @@
-// Options Entry Point - Step 9에서 구현 예정
-export {};
+// Options 페이지 진입점
+// API 키 설정, 다크모드 토글, 언어 선택 기능을 담당한다.
+
+import './options.css';
+import { initI18n, t, setLanguage, getCurrentLanguage, getSupportedLanguages } from '../i18n';
+import { getStorage, setStorage } from '../utils/storage.util';
+import { STORAGE_KEY_API_KEY, STORAGE_KEY_THEME, THEME_DARK, THEME_LIGHT } from '../constants';
+import type { Language } from '../types/storage.types';
+
+// ── DOM 참조 ───────────────────────────────────────────────
+
+const apiKeyInput    = document.getElementById('api-key')        as HTMLInputElement;
+const setupBtn       = document.getElementById('setup-btn')      as HTMLButtonElement;
+const visibilityBtn  = document.getElementById('visibility-btn') as HTMLButtonElement;
+const eyeIcon        = document.getElementById('eye-icon')       as HTMLSpanElement;
+const saveMessage    = document.getElementById('save-message')   as HTMLParagraphElement;
+const themeToggleBtn = document.getElementById('theme-toggle')   as HTMLButtonElement;
+const langBtn        = document.getElementById('lang-btn')       as HTMLButtonElement;
+const langMenu       = document.getElementById('lang-menu')      as HTMLDivElement;
+const langLabel      = document.getElementById('lang-label')     as HTMLSpanElement;
+
+// ── 다크모드 ───────────────────────────────────────────────
+
+async function initTheme(): Promise<void> {
+  const saved = await getStorage(STORAGE_KEY_THEME);
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = saved ? saved === THEME_DARK : prefersDark;
+  document.documentElement.classList.toggle('dark', isDark);
+}
+
+function toggleTheme(): void {
+  const isDark = document.documentElement.classList.toggle('dark');
+  void setStorage({ [STORAGE_KEY_THEME]: isDark ? THEME_DARK : THEME_LIGHT });
+}
+
+// ── 비밀번호 가시성 토글 ───────────────────────────────────
+
+function toggleVisibility(): void {
+  const isPassword = apiKeyInput.type === 'password';
+  apiKeyInput.type = isPassword ? 'text' : 'password';
+  eyeIcon.textContent = isPassword ? 'visibility_off' : 'visibility';
+}
+
+// ── 저장 메시지 표시 ───────────────────────────────────────
+
+function showSaveMessage(text: string, type: 'success' | 'error'): void {
+  saveMessage.textContent = text;
+  saveMessage.className = `save-message ${type}`;
+  setTimeout(() => {
+    saveMessage.className = 'save-message hidden';
+  }, 3000);
+}
+
+// ── API 키 저장 ────────────────────────────────────────────
+
+async function saveApiKey(): Promise<void> {
+  const apiKey = apiKeyInput.value.trim();
+
+  if (!apiKey) {
+    showSaveMessage(t('options', 'errorEmptyKey'), 'error');
+    return;
+  }
+
+  await setStorage({ [STORAGE_KEY_API_KEY]: apiKey });
+  showSaveMessage(t('options', 'savedMessage'), 'success');
+}
+
+// ── 언어 드롭다운 ──────────────────────────────────────────
+
+function openLangMenu(): void {
+  langMenu.classList.add('open');
+  langBtn.setAttribute('aria-expanded', 'true');
+}
+
+function closeLangMenu(): void {
+  langMenu.classList.remove('open');
+  langBtn.setAttribute('aria-expanded', 'false');
+}
+
+function toggleLangMenu(): void {
+  langMenu.classList.contains('open') ? closeLangMenu() : openLangMenu();
+}
+
+async function handleLangSelect(lang: Language): Promise<void> {
+  await setLanguage(lang);
+  closeLangMenu();
+  applyI18n();
+  updateActiveLangItem();
+}
+
+function updateActiveLangItem(): void {
+  const current = getCurrentLanguage();
+  document.querySelectorAll<HTMLAnchorElement>('.lang-item').forEach((el) => {
+    el.classList.toggle('active', el.dataset.lang === current);
+  });
+  // 헤더 언어 버튼 레이블 업데이트
+  const langs = getSupportedLanguages();
+  const found = langs.find((l) => l.code === current);
+  if (found) langLabel.textContent = found.label;
+}
+
+// ── i18n 적용 ──────────────────────────────────────────────
+
+function applyI18n(): void {
+  // data-i18n 속성을 가진 요소 텍스트 교체
+  document.querySelectorAll<HTMLElement>('[data-i18n]').forEach((el) => {
+    const key = el.dataset.i18n ?? '';
+    const [section, k] = key.split('.') as [string, string];
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      el.textContent = t(section as any, k as any);
+    } catch {
+      // 키가 없으면 그대로 유지
+    }
+  });
+
+  // data-i18n-placeholder 속성을 가진 input placeholder 교체
+  document.querySelectorAll<HTMLInputElement>('[data-i18n-placeholder]').forEach((el) => {
+    const key = el.dataset.i18nPlaceholder ?? '';
+    const [section, k] = key.split('.') as [string, string];
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      el.placeholder = t(section as any, k as any);
+    } catch {
+      // 키가 없으면 그대로 유지
+    }
+  });
+}
+
+// ── 저장된 API 키 로드 ─────────────────────────────────────
+
+async function loadApiKey(): Promise<void> {
+  const saved = await getStorage(STORAGE_KEY_API_KEY);
+  if (saved) apiKeyInput.value = saved;
+}
+
+// ── 이벤트 등록 ───────────────────────────────────────────
+
+function bindEvents(): void {
+  // API 키 저장
+  setupBtn.addEventListener('click', () => { void saveApiKey(); });
+  apiKeyInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') void saveApiKey();
+  });
+
+  // 비밀번호 가시성
+  visibilityBtn.addEventListener('click', toggleVisibility);
+
+  // 다크모드
+  themeToggleBtn.addEventListener('click', toggleTheme);
+
+  // 언어 드롭다운 - 버튼 클릭 토글
+  langBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleLangMenu();
+  });
+
+  // 언어 선택
+  document.querySelectorAll<HTMLAnchorElement>('.lang-item').forEach((el) => {
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      const lang = el.dataset.lang as Language;
+      if (lang) void handleLangSelect(lang);
+    });
+  });
+
+  // 외부 클릭 시 드롭다운 닫기
+  document.addEventListener('click', (e) => {
+    if (!langBtn.contains(e.target as Node) && !langMenu.contains(e.target as Node)) {
+      closeLangMenu();
+    }
+  });
+}
+
+// ── 초기화 ────────────────────────────────────────────────
+
+async function init(): Promise<void> {
+  await initTheme();
+  await initI18n();
+  await loadApiKey();
+  applyI18n();
+  updateActiveLangItem();
+  bindEvents();
+}
+
+void init();

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,0 +1,343 @@
+/* Options 페이지 스타일 */
+/* 디자인 레퍼런스: .claude/skills/extension-setup-screen.html */
+
+/* ── CSS 변수 (라이트 모드) ─────────────────────────────── */
+:root {
+  --color-primary:         #EF4444;
+  --color-primary-hover:   #DC2626;
+  --color-bg:              #F9FAFB;
+  --color-surface:         #FFFFFF;
+  --color-text:            #1F2937;
+  --color-text-muted:      #6B7280;
+  --color-text-sub:        #4B5563;
+  --color-border:          #E5E7EB;
+  --color-input-bg:        #FFFFFF;
+  --color-input-text:      #111827;
+  --color-input-border:    #D1D5DB;
+  --color-hover-bg:        #F3F4F6;
+  --color-icon:            #6B7280;
+  --color-icon-hover:      #374151;
+  --shadow-card:           0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -2px rgba(0,0,0,.05);
+  --shadow-btn:            0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -1px rgba(0,0,0,.06);
+  --shadow-btn-hover:      0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -2px rgba(0,0,0,.05);
+  --radius-card:           0.75rem;
+  --radius-input:          0.5rem;
+  --transition-base:       background-color 0.3s ease, color 0.3s ease, border-color 0.2s ease;
+}
+
+/* ── 다크 모드 변수 ─────────────────────────────────────── */
+html.dark {
+  --color-bg:              #111827;
+  --color-surface:         #1F2937;
+  --color-text:            #F3F4F6;
+  --color-text-muted:      #9CA3AF;
+  --color-text-sub:        #D1D5DB;
+  --color-border:          #374151;
+  --color-input-bg:        #1F2937;
+  --color-input-text:      #F9FAFB;
+  --color-input-border:    #4B5563;
+  --color-hover-bg:        #374151;
+  --color-icon:            #9CA3AF;
+  --color-icon-hover:      #E5E7EB;
+}
+
+/* ── 기본 리셋 ──────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body { font-family: 'Inter', sans-serif; }
+
+a { text-decoration: none; }
+
+/* ── Body ────────────────────────────────────────────────── */
+.options-body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  transition: var(--transition-base);
+}
+
+/* ── Card ────────────────────────────────────────────────── */
+.options-card {
+  width: 100%;
+  max-width: 42rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  transition: var(--transition-base);
+}
+
+/* ── Header ─────────────────────────────────────────────── */
+.options-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+  transition: border-color 0.2s ease;
+}
+
+/* Language Dropdown */
+.lang-dropdown-wrapper {
+  position: relative;
+}
+
+.lang-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-sub);
+  background: transparent;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+.lang-btn:hover {
+  color: var(--color-primary);
+  background-color: var(--color-hover-bg);
+}
+.lang-btn:focus { outline: none; }
+
+.lang-menu {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.5rem);
+  width: 8rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,.1);
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0.5rem);
+  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+}
+.lang-menu.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.lang-menu ul { list-style: none; padding: 0.25rem 0; }
+
+.lang-item {
+  display: block;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  transition: background-color 0.15s ease;
+}
+.lang-item:hover { background-color: var(--color-hover-bg); }
+.lang-item.active { color: var(--color-primary); font-weight: 600; }
+
+/* Theme Toggle */
+.theme-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  background: transparent;
+  border: none;
+  border-radius: 9999px;
+  color: var(--color-icon);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.theme-btn:hover {
+  background-color: var(--color-hover-bg);
+  color: var(--color-icon-hover);
+}
+.theme-btn:focus { outline: none; }
+
+/* 다크모드 아이콘 토글 */
+#theme-icon-dark { display: none; color: #FCD34D; }
+html.dark #theme-icon-light { display: none; }
+html.dark #theme-icon-dark { display: inline; }
+
+/* ── Main ────────────────────────────────────────────────── */
+.options-main {
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+  min-height: 400px;
+}
+
+/* Title */
+.options-title-wrap { text-align: center; display: flex; flex-direction: column; gap: 0.5rem; }
+
+.options-title {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  background: linear-gradient(to right, #111827, #4B5563);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+html.dark .options-title {
+  background: linear-gradient(to right, #FFFFFF, #D1D5DB);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.options-subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+/* Form */
+.options-form {
+  width: 100%;
+  max-width: 28rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group { display: flex; flex-direction: column; gap: 0.375rem; }
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-sub);
+  margin-left: 0.25rem;
+}
+
+.input-wrapper { position: relative; }
+
+.form-input {
+  width: 100%;
+  padding: 0.75rem 2.75rem 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-family: 'Inter', sans-serif;
+  color: var(--color-input-text);
+  background-color: var(--color-input-bg);
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-input);
+  box-shadow: 0 1px 2px rgba(0,0,0,.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(239,68,68,.15);
+}
+.form-input::placeholder { color: var(--color-text-muted); }
+
+.visibility-btn {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  padding-right: 0.75rem;
+  background: transparent;
+  border: none;
+  color: var(--color-icon);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+.visibility-btn:hover { color: var(--color-icon-hover); }
+.visibility-btn:focus { outline: none; }
+
+/* Save Message */
+.save-message {
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+}
+.save-message.success {
+  color: #065F46;
+  background-color: #D1FAE5;
+}
+.save-message.error {
+  color: #991B1B;
+  background-color: #FEE2E2;
+}
+html.dark .save-message.success {
+  color: #6EE7B7;
+  background-color: #064E3B;
+}
+html.dark .save-message.error {
+  color: #FCA5A5;
+  background-color: #7F1D1D;
+}
+.hidden { display: none !important; }
+
+/* Setup Button */
+.form-submit { display: flex; justify-content: center; padding-top: 0.5rem; }
+
+.setup-btn {
+  background-color: var(--color-primary);
+  color: #FFFFFF;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  font-family: 'Inter', sans-serif;
+  padding: 0.625rem 2rem;
+  border: none;
+  border-radius: 9999px;
+  box-shadow: var(--shadow-btn);
+  cursor: pointer;
+  width: 100%;
+  max-width: 20rem;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+.setup-btn:hover {
+  background-color: var(--color-primary-hover);
+  box-shadow: var(--shadow-btn-hover);
+  transform: translateY(-1px);
+}
+.setup-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(239,68,68,.4);
+}
+
+/* ── Footer ─────────────────────────────────────────────── */
+.options-footer {
+  width: 100%;
+  max-width: 28rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+  transition: border-color 0.2s ease;
+}
+
+.footer-text {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.footer-link {
+  font-weight: 500;
+  color: var(--color-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  transition: color 0.2s ease;
+}
+.footer-link:hover {
+  color: var(--color-primary-hover);
+  text-decoration: underline;
+}
+
+/* ── Material Icons 크기 유틸 ─────────────────────────────── */
+.icon-sm { font-size: 1.125rem !important; }
+.icon-xs { font-size: 0.875rem !important; }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,13 +1,113 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>YouTube Timestamp Comments - Setup</title>
   <link rel="stylesheet" href="index.css" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    rel="stylesheet"
+  />
 </head>
-<body>
-  <div id="app"></div>
+<body class="options-body">
+  <div class="options-card">
+
+    <!-- ── Header ── -->
+    <header class="options-header">
+
+      <!-- Language Dropdown -->
+      <div class="lang-dropdown-wrapper">
+        <button class="lang-btn" id="lang-btn" aria-haspopup="true" aria-expanded="false">
+          <span class="material-icons icon-sm">language</span>
+          <span id="lang-label">Language</span>
+          <span class="material-icons icon-xs">expand_more</span>
+        </button>
+        <div class="lang-menu" id="lang-menu" role="menu">
+          <ul>
+            <li><a href="#" class="lang-item" data-lang="en" role="menuitem">English</a></li>
+            <li><a href="#" class="lang-item" data-lang="ko" role="menuitem">한국어</a></li>
+            <li><a href="#" class="lang-item" data-lang="ja" role="menuitem">日本語</a></li>
+            <li><a href="#" class="lang-item" data-lang="zh" role="menuitem">中文</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Dark Mode Toggle -->
+      <button class="theme-btn" id="theme-toggle" aria-label="Toggle dark mode">
+        <span class="material-icons" id="theme-icon-light">dark_mode</span>
+        <span class="material-icons theme-icon-dark" id="theme-icon-dark">light_mode</span>
+      </button>
+
+    </header>
+
+    <!-- ── Main ── -->
+    <main class="options-main">
+
+      <!-- Title -->
+      <div class="options-title-wrap">
+        <h1 class="options-title" data-i18n="options.title">YouTube Timestamp Comments</h1>
+        <p class="options-subtitle" data-i18n="options.subtitle">
+          Enhance your viewing experience with timestamped notes.
+        </p>
+      </div>
+
+      <!-- API Key Form -->
+      <div class="options-form">
+
+        <div class="form-group">
+          <label class="form-label" for="api-key" data-i18n="options.apiKeyLabel">API Key</label>
+          <div class="input-wrapper">
+            <input
+              class="form-input"
+              id="api-key"
+              name="api-key"
+              type="password"
+              data-i18n-placeholder="options.apiKeyPlaceholder"
+              placeholder="Enter your API Key here"
+              autocomplete="off"
+            />
+            <button class="visibility-btn" id="visibility-btn" type="button" aria-label="Toggle API key visibility">
+              <span class="material-icons" id="eye-icon">visibility</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Save Message -->
+        <p class="save-message hidden" id="save-message" role="alert"></p>
+
+        <div class="form-submit">
+          <button class="setup-btn" id="setup-btn" type="button" data-i18n="options.setupButton">
+            Set up
+          </button>
+        </div>
+
+      </div>
+
+      <!-- Footer -->
+      <div class="options-footer">
+        <p class="footer-text">
+          <span data-i18n="options.guideText">Need help finding your API Key?</span>
+          <a
+            class="footer-link"
+            href="https://developers.google.com/youtube/v3/getting-started"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-i18n="options.guideLink"
+          >
+            Read the guide
+            <span class="material-icons icon-xs">open_in_new</span>
+          </a>
+        </p>
+      </div>
+
+    </main>
+  </div>
+
   <script src="index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Issue #14 
- Add options.html with language dropdown, dark mode toggle, API key input
- Add options.css with CSS variable-based light/dark theme system
- Add options/index.ts with API key save, visibility toggle, theme/language persistence
- Apply i18n via data-i18n attribute binding