### PR TITLE
fix: translate API key error message using i18n

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -81,6 +81,7 @@ async function handleFetchComments(
         type: MessageType.ERROR,
         error: 'API Key is not set. Please go to Settings.',
         code: 401,
+        errorCode: 'NO_API_KEY',
       });
       return;
     }
@@ -114,6 +115,7 @@ async function handleFetchReplies(
         type: MessageType.ERROR,
         error: 'API Key is not set. Please go to Settings.',
         code: 401,
+        errorCode: 'NO_API_KEY',
       });
       return;
     }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,7 +4,7 @@
 import { fetchCommentThreads, fetchReplies, YouTubeApiError } from '../services/youtube.service';
 import { getStorage } from '../utils/storage.util';
 import { STORAGE_KEY_API_KEY } from '../constants';
-import { MessageType } from '../types/message.types';
+import { MessageType, ErrorCode } from '../types/message.types';
 import type {
   RequestMessage,
   FetchCommentsRequest,
@@ -67,6 +67,15 @@ async function getApiKey(): Promise<string | null> {
   return apiKey ?? null;
 }
 
+// ── 공통 에러 응답 상수 ────────────────────────────────────
+
+const NO_API_KEY_ERROR: ResponseMessage = {
+  type: MessageType.ERROR,
+  error: 'API Key is not set. Please go to Settings.',
+  code: 401,
+  errorCode: ErrorCode.NO_API_KEY,
+};
+
 // ── FETCH_COMMENTS 처리 ────────────────────────────────────
 
 async function handleFetchComments(
@@ -77,12 +86,7 @@ async function handleFetchComments(
     const apiKey = await getApiKey();
 
     if (!apiKey) {
-      sendResponse({
-        type: MessageType.ERROR,
-        error: 'API Key is not set. Please go to Settings.',
-        code: 401,
-        errorCode: 'NO_API_KEY',
-      });
+      sendResponse(NO_API_KEY_ERROR);
       return;
     }
 
@@ -111,12 +115,7 @@ async function handleFetchReplies(
     const apiKey = await getApiKey();
 
     if (!apiKey) {
-      sendResponse({
-        type: MessageType.ERROR,
-        error: 'API Key is not set. Please go to Settings.',
-        code: 401,
-        errorCode: 'NO_API_KEY',
-      });
+      sendResponse(NO_API_KEY_ERROR);
       return;
     }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -21,8 +21,8 @@ export const STORAGE_KEY_THEME = 'theme';
 export const STORAGE_KEY_LANGUAGE = 'language';
 
 // ── 다크모드 ───────────────────────────────────────────────
-export const THEME_DARK = 'dark' as const;
-export const THEME_LIGHT = 'light' as const;
+export const THEME_DARK = 'dark';
+export const THEME_LIGHT = 'light';
 
 // ── 기본 언어 ──────────────────────────────────────────────
-export const DEFAULT_LANGUAGE = 'en' as const;
+export const DEFAULT_LANGUAGE = 'en';

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -199,7 +199,13 @@ async function fetchComments(
   return new Promise((resolve, reject) => {
     chrome.runtime.sendMessage(request, (response: FetchCommentsResponse | ErrorResponse) => {
       if (chrome.runtime.lastError) { reject(new Error(chrome.runtime.lastError.message)); return; }
-      if (response.type === MessageType.ERROR) { reject(new Error(response.error)); return; }
+      if (response.type === MessageType.ERROR) {
+        const errMsg = response.errorCode === 'NO_API_KEY'
+          ? t('popup', 'errorNoApiKey')
+          : response.error;
+        reject(new Error(errMsg));
+        return;
+      }
       resolve({
         items: (response).payload.items,
         nextPageToken: (response).payload.nextPageToken,

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -2,7 +2,7 @@
 // 사이드바 + 헤더 + 댓글 목록으로 구성된 메인 화면을 렌더링한다.
 
 import { t } from '../../i18n';
-import { MessageType } from '../../types/message.types';
+import { MessageType, ErrorCode } from '../../types/message.types';
 import type { FetchCommentsRequest, FetchCommentsResponse, ErrorResponse } from '../../types/message.types';
 import type { CommentThread, CommentOrder } from '../../types/youtube.types';
 import { hasTimestamp, extractTimestamps, filterCommentsByTimestampRange } from '../../utils/timestamp.util';
@@ -200,7 +200,7 @@ async function fetchComments(
     chrome.runtime.sendMessage(request, (response: FetchCommentsResponse | ErrorResponse) => {
       if (chrome.runtime.lastError) { reject(new Error(chrome.runtime.lastError.message)); return; }
       if (response.type === MessageType.ERROR) {
-        const errMsg = response.errorCode === 'NO_API_KEY'
+        const errMsg = response.errorCode === ErrorCode.NO_API_KEY
           ? t('popup', 'errorNoApiKey')
           : response.error;
         reject(new Error(errMsg));

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -64,6 +64,7 @@ export interface ErrorResponse {
   type: MessageType.ERROR;
   error: string;
   code?: number;
+  errorCode?: 'NO_API_KEY';
 }
 
 export type ResponseMessage =

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -9,6 +9,11 @@ export enum MessageType {
   ERROR = 'ERROR',
 }
 
+export enum ErrorCode {
+  NO_API_KEY = 'NO_API_KEY',
+  // 향후 에러 코드 추가 시 여기에 작성
+}
+
 // ── 요청 타입 ──────────────────────────────────────────────
 
 export interface FetchCommentsRequest {
@@ -64,7 +69,7 @@ export interface ErrorResponse {
   type: MessageType.ERROR;
   error: string;
   code?: number;
-  errorCode?: 'NO_API_KEY';
+  errorCode?: ErrorCode;
 }
 
 export type ResponseMessage =


### PR DESCRIPTION
Issue #23 
- background에서 하드코딩된 영어 에러 문자열 대신 errorCode: 'NO_API_KEY'를
- 전달하고, popup에서 t()로 번역된 메시지를 표시하도록 수정