### PR TITLE
feat: seek YouTube video on timestamp click

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,9 +1,10 @@
 // Content Script
 // YouTube 페이지에서 현재 영상의 videoId를 추출한다.
 // Popup이 chrome.tabs.sendMessage로 GET_VIDEO_ID를 요청하면 응답한다.
+// Popup이 chrome.tabs.sendMessage로 SEEK_TO를 요청하면 영상 시간을 이동한다.
 
 import { MessageType } from '../types/message.types';
-import type { GetVideoIdRequest, GetVideoIdResponse } from '../types/message.types';
+import type { GetVideoIdRequest, GetVideoIdResponse, SeekToRequest } from '../types/message.types';
 
 // ── videoId 추출 ───────────────────────────────────────────
 
@@ -16,13 +17,21 @@ function extractVideoId(): string | null {
   return url.searchParams.get('v');
 }
 
-// ── Popup 요청 리스너 ──────────────────────────────────────
-// Popup이 chrome.tabs.sendMessage(tabId, { type: GET_VIDEO_ID })로 요청하면
-// 현재 videoId를 응답한다.
+// ── 영상 시간 이동 ─────────────────────────────────────────
+
+/**
+ * YouTube 영상 <video> 요소의 currentTime을 변경해 특정 구간으로 이동한다.
+ */
+function seekTo(seconds: number): void {
+  const video = document.querySelector<HTMLVideoElement>('video');
+  if (video) video.currentTime = seconds;
+}
+
+// ── 메시지 리스너 ──────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener(
   (
-    message: GetVideoIdRequest,
+    message: GetVideoIdRequest | SeekToRequest,
     _sender: chrome.runtime.MessageSender,
     sendResponse: (response: GetVideoIdResponse) => void,
   ) => {
@@ -32,6 +41,9 @@ chrome.runtime.onMessage.addListener(
         payload: { videoId: extractVideoId() },
       });
     }
-    // 동기 응답이므로 true 반환 불필요
+
+    if (message.type === MessageType.SEEK_TO) {
+      seekTo(message.payload.seconds);
+    }
   },
 );

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "View and search YouTube comments containing timestamps",
 
-  "permissions": ["storage", "activeTab"],
+  "permissions": ["storage", "activeTab", "tabs"],
   "host_permissions": [
     "https://www.youtube.com/*",
     "https://www.googleapis.com/youtube/v3/*"

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -10,14 +10,18 @@ import { router } from './router';
 import { mountMainPage } from './pages/MainPage';
 import { mountSettingsPage } from './pages/SettingsPage';
 
-// ── videoId 추출 ──────────────────────────────────────────
+// ── videoId / tabId 추출 ──────────────────────────────────
 
-async function getVideoIdFromTab(): Promise<string | null> {
+async function getTabInfo(): Promise<{ videoId: string | null; tabId: number | null }> {
   return new Promise((resolve) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const url = tabs[0]?.url ?? '';
+      const tab = tabs[0];
+      const url = tab?.url ?? '';
       const match = url.match(/[?&]v=([^&]+)/);
-      resolve(match?.[1] ?? null);
+      resolve({
+        videoId: match?.[1] ?? null,
+        tabId: tab?.id ?? null,
+      });
     });
   });
 }
@@ -32,22 +36,22 @@ async function main(): Promise<void> {
   // i18n 초기화
   await initI18n();
 
-  // videoId 사전 추출 (MainPage에서 사용)
-  const videoId = await getVideoIdFromTab();
+  // videoId / tabId 사전 추출
+  const { videoId, tabId } = await getTabInfo();
 
   const root = document.getElementById('root')!;
 
   // 라우트 변경 시 페이지 전환
   router.onRouteChange((route) => {
     if (route === '/') {
-      void mountMainPage(root, videoId);
+      void mountMainPage(root, videoId, tabId);
     } else if (route === '/settings') {
       mountSettingsPage(root);
     }
   });
 
   // 초기 라우트 — 메인 페이지
-  void mountMainPage(root, videoId);
+  void mountMainPage(root, videoId, tabId);
 }
 
 document.addEventListener('DOMContentLoaded', () => { void main(); });

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -13,17 +13,14 @@ import { mountSettingsPage } from './pages/SettingsPage';
 // ── videoId / tabId 추출 ──────────────────────────────────
 
 async function getTabInfo(): Promise<{ videoId: string | null; tabId: number | null }> {
-  return new Promise((resolve) => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const tab = tabs[0];
-      const url = tab?.url ?? '';
-      const match = url.match(/[?&]v=([^&]+)/);
-      resolve({
-        videoId: match?.[1] ?? null,
-        tabId: tab?.id ?? null,
-      });
-    });
-  });
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tab = tabs[0];
+  const url = tab?.url ?? '';
+  const match = url.match(/[?&]v=([^&]+)/);
+  return {
+    videoId: match?.[1] ?? null,
+    tabId: tab?.id ?? null,
+  };
 }
 
 // ── 진입점 ────────────────────────────────────────────────

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -5,7 +5,7 @@ import { t } from '../../i18n';
 import { MessageType, ErrorCode } from '../../types/message.types';
 import type { FetchCommentsRequest, FetchCommentsResponse, ErrorResponse } from '../../types/message.types';
 import type { CommentThread, CommentOrder } from '../../types/youtube.types';
-import { hasTimestamp, extractTimestamps, filterCommentsByTimestampRange } from '../../utils/timestamp.util';
+import { hasTimestamp, extractTimestamps, filterCommentsByTimestampRange, timestampToSeconds } from '../../utils/timestamp.util';
 import { Header } from '../components/Header';
 import { TimestampSidebar } from '../components/TimestampSidebar';
 import { TimestampModal } from '../components/TimestampModal';
@@ -249,7 +249,7 @@ async function loadComments(
 
 // ── 마운트 ────────────────────────────────────────────────
 
-export async function mountMainPage(root: HTMLElement, videoId: string | null): Promise<void> {
+export async function mountMainPage(root: HTMLElement, videoId: string | null, tabId: number | null): Promise<void> {
   root.innerHTML = getMainPageHTML();
 
   currentVideoId = videoId;
@@ -275,6 +275,24 @@ export async function mountMainPage(root: HTMLElement, videoId: string | null): 
 
   header.applyI18n();
   modal.applyI18n();
+
+  // 타임스탬프 링크 클릭 → 영상 해당 구간으로 이동 (이벤트 위임)
+  if (tabId !== null) {
+    const listEl = getEl('comment-list');
+    listEl.addEventListener('click', (e) => {
+      const link = (e.target as HTMLElement).closest<HTMLElement>('.comment-ts-link');
+      if (!link) return;
+      e.preventDefault();
+      const ts = link.dataset.timestamp;
+      if (!ts) return;
+      // 콜백을 넘겨 lastError를 소비함으로써 content script 미주입 탭에서의 uncaught 오류 방지
+      chrome.tabs.sendMessage(
+        tabId,
+        { type: 'SEEK_TO', payload: { seconds: timestampToSeconds(ts) } },
+        () => { void chrome.runtime.lastError; },
+      );
+    });
+  }
 
   if (!currentVideoId) {
     showStatus('error', t('popup', 'errorNoVideo'));

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -288,7 +288,7 @@ export async function mountMainPage(root: HTMLElement, videoId: string | null, t
       // 콜백을 넘겨 lastError를 소비함으로써 content script 미주입 탭에서의 uncaught 오류 방지
       chrome.tabs.sendMessage(
         tabId,
-        { type: 'SEEK_TO', payload: { seconds: timestampToSeconds(ts) } },
+        { type: MessageType.SEEK_TO, payload: { seconds: timestampToSeconds(ts) } },
         () => { void chrome.runtime.lastError; },
       );
     });

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -6,6 +6,7 @@ export enum MessageType {
   FETCH_COMMENTS = 'FETCH_COMMENTS',
   FETCH_REPLIES = 'FETCH_REPLIES',
   GET_VIDEO_ID = 'GET_VIDEO_ID',
+  SEEK_TO = 'SEEK_TO',
   ERROR = 'ERROR',
 }
 
@@ -34,6 +35,11 @@ export interface FetchRepliesRequest {
 
 export interface GetVideoIdRequest {
   type: MessageType.GET_VIDEO_ID;
+}
+
+export interface SeekToRequest {
+  type: MessageType.SEEK_TO;
+  payload: { seconds: number };
 }
 
 export type RequestMessage =


### PR DESCRIPTION
## Issue
#26 

## Summary
댓글의 타임스탬프 클릭 시 YouTube 영상의 해당 구간으로 이동하는 기능 추가

## Changes
- `manifest.json` — `tabs` 권한 추가
- `message.types.ts` — `SEEK_TO` 메시지 타입 추가
- `content/index.ts` — `SEEK_TO` 수신 시 `video.currentTime` 변경
- `popup/index.ts` — `tabId` 추출 후 MainPage에 전달
- `MainPage.ts` — 타임스탬프 링크 클릭 이벤트 위임, `chrome.tabs.sendMessage`로 SEEK_TO 전송