### PR TITLE
fix: preserve comment state across navigation and popup reopen

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,6 +20,12 @@ export const STORAGE_KEY_API_KEY = 'apiKey';
 export const STORAGE_KEY_THEME = 'theme';
 export const STORAGE_KEY_LANGUAGE = 'language';
 
+// ── Session 캐시 키 ────────────────────────────────────────
+export const SESSION_KEY_COMMENTS = 'cachedComments';
+export const SESSION_KEY_VIDEO_ID = 'cachedVideoId';
+export const SESSION_KEY_NEXT_PAGE_TOKEN = 'cachedNextPageToken';
+export const SESSION_KEY_ORDER = 'cachedOrder';
+
 // ── 다크모드 ───────────────────────────────────────────────
 export const THEME_DARK = 'dark';
 export const THEME_LIGHT = 'light';

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -252,6 +252,7 @@ async function loadComments(
 export async function mountMainPage(root: HTMLElement, videoId: string | null, tabId: number | null): Promise<void> {
   root.innerHTML = getMainPageHTML();
 
+  const prevVideoId = currentVideoId;
   currentVideoId = videoId;
 
   const headerEl   = getEl('popup-header');
@@ -297,6 +298,15 @@ export async function mountMainPage(root: HTMLElement, videoId: string | null, t
   if (!currentVideoId) {
     showStatus('error', t('popup', 'errorNoVideo'));
     header.updateCommentCount(0, false);
+    return;
+  }
+
+  // 동일 videoId로 재진입 시 (예: 설정 페이지 갔다가 돌아온 경우)
+  // 기존 댓글 상태를 그대로 복원해 불필요한 API 재호출 방지
+  if (videoId === prevVideoId && allComments.length > 0) {
+    header.updateCommentCount(allComments.length, !!nextPageToken);
+    rebuildSidebar(sidebar);
+    renderComments(displayedComments);
     return;
   }
 

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -316,34 +316,37 @@ export async function mountMainPage(root: HTMLElement, videoId: string | null, t
     return;
   }
 
+  let restoredFromCache = false;
+
   // 동일 videoId로 재진입 시 (예: 설정 페이지 갔다가 돌아온 경우)
   // 기존 댓글 상태를 그대로 복원해 불필요한 API 재호출 방지
   if (videoId === prevVideoId && allComments.length > 0) {
-    header.updateCommentCount(allComments.length, !!nextPageToken);
-    rebuildSidebar(sidebar);
-    renderComments(displayedComments);
-    return;
+    restoredFromCache = true;
+  } else {
+    // 팝업을 닫았다 다시 열었을 때 세션 캐시로 복원
+    type SessionCache = {
+      [SESSION_KEY_COMMENTS]: CommentThread[];
+      [SESSION_KEY_VIDEO_ID]: string;
+      [SESSION_KEY_NEXT_PAGE_TOKEN]: string | null;
+      [SESSION_KEY_ORDER]: CommentOrder;
+    };
+    const cache = await getSessionStorageMultiple<SessionCache>([
+      SESSION_KEY_COMMENTS,
+      SESSION_KEY_VIDEO_ID,
+      SESSION_KEY_NEXT_PAGE_TOKEN,
+      SESSION_KEY_ORDER,
+    ]);
+
+    if (cache[SESSION_KEY_VIDEO_ID] === videoId && cache[SESSION_KEY_COMMENTS]?.length) {
+      allComments = cache[SESSION_KEY_COMMENTS];
+      displayedComments = allComments;
+      nextPageToken = cache[SESSION_KEY_NEXT_PAGE_TOKEN] ?? undefined;
+      currentOrder = cache[SESSION_KEY_ORDER] ?? 'relevance';
+      restoredFromCache = true;
+    }
   }
 
-  // 팝업을 닫았다 다시 열었을 때 세션 캐시로 복원
-  type SessionCache = {
-    [SESSION_KEY_COMMENTS]: CommentThread[];
-    [SESSION_KEY_VIDEO_ID]: string;
-    [SESSION_KEY_NEXT_PAGE_TOKEN]: string | null;
-    [SESSION_KEY_ORDER]: CommentOrder;
-  };
-  const cache = await getSessionStorageMultiple<SessionCache>([
-    SESSION_KEY_COMMENTS,
-    SESSION_KEY_VIDEO_ID,
-    SESSION_KEY_NEXT_PAGE_TOKEN,
-    SESSION_KEY_ORDER,
-  ]);
-
-  if (cache[SESSION_KEY_VIDEO_ID] === videoId && cache[SESSION_KEY_COMMENTS]?.length) {
-    allComments = cache[SESSION_KEY_COMMENTS];
-    displayedComments = allComments;
-    nextPageToken = cache[SESSION_KEY_NEXT_PAGE_TOKEN] ?? undefined;
-    currentOrder = cache[SESSION_KEY_ORDER] ?? 'relevance';
+  if (restoredFromCache) {
     header.updateCommentCount(allComments.length, !!nextPageToken);
     rebuildSidebar(sidebar);
     renderComments(displayedComments);

--- a/src/popup/pages/MainPage.ts
+++ b/src/popup/pages/MainPage.ts
@@ -6,6 +6,13 @@ import { MessageType, ErrorCode } from '../../types/message.types';
 import type { FetchCommentsRequest, FetchCommentsResponse, ErrorResponse } from '../../types/message.types';
 import type { CommentThread, CommentOrder } from '../../types/youtube.types';
 import { hasTimestamp, extractTimestamps, filterCommentsByTimestampRange, timestampToSeconds } from '../../utils/timestamp.util';
+import { getSessionStorageMultiple, setSessionStorage } from '../../utils/storage.util';
+import {
+  SESSION_KEY_COMMENTS,
+  SESSION_KEY_VIDEO_ID,
+  SESSION_KEY_NEXT_PAGE_TOKEN,
+  SESSION_KEY_ORDER,
+} from '../../constants';
 import { Header } from '../components/Header';
 import { TimestampSidebar } from '../components/TimestampSidebar';
 import { TimestampModal } from '../components/TimestampModal';
@@ -237,6 +244,14 @@ async function loadComments(
     nextPageToken = result.nextPageToken;
     displayedComments = allComments;
 
+    // 팝업 재진입 시 복원을 위해 세션에 캐싱
+    void setSessionStorage({
+      [SESSION_KEY_COMMENTS]: allComments,
+      [SESSION_KEY_VIDEO_ID]: currentVideoId,
+      [SESSION_KEY_NEXT_PAGE_TOKEN]: nextPageToken ?? null,
+      [SESSION_KEY_ORDER]: currentOrder,
+    });
+
     header.updateCommentCount(allComments.length, !!nextPageToken);
     rebuildSidebar(sidebar);
     renderComments(displayedComments);
@@ -304,6 +319,31 @@ export async function mountMainPage(root: HTMLElement, videoId: string | null, t
   // 동일 videoId로 재진입 시 (예: 설정 페이지 갔다가 돌아온 경우)
   // 기존 댓글 상태를 그대로 복원해 불필요한 API 재호출 방지
   if (videoId === prevVideoId && allComments.length > 0) {
+    header.updateCommentCount(allComments.length, !!nextPageToken);
+    rebuildSidebar(sidebar);
+    renderComments(displayedComments);
+    return;
+  }
+
+  // 팝업을 닫았다 다시 열었을 때 세션 캐시로 복원
+  type SessionCache = {
+    [SESSION_KEY_COMMENTS]: CommentThread[];
+    [SESSION_KEY_VIDEO_ID]: string;
+    [SESSION_KEY_NEXT_PAGE_TOKEN]: string | null;
+    [SESSION_KEY_ORDER]: CommentOrder;
+  };
+  const cache = await getSessionStorageMultiple<SessionCache>([
+    SESSION_KEY_COMMENTS,
+    SESSION_KEY_VIDEO_ID,
+    SESSION_KEY_NEXT_PAGE_TOKEN,
+    SESSION_KEY_ORDER,
+  ]);
+
+  if (cache[SESSION_KEY_VIDEO_ID] === videoId && cache[SESSION_KEY_COMMENTS]?.length) {
+    allComments = cache[SESSION_KEY_COMMENTS];
+    displayedComments = allComments;
+    nextPageToken = cache[SESSION_KEY_NEXT_PAGE_TOKEN] ?? undefined;
+    currentOrder = cache[SESSION_KEY_ORDER] ?? 'relevance';
     header.updateCommentCount(allComments.length, !!nextPageToken);
     rebuildSidebar(sidebar);
     renderComments(displayedComments);

--- a/src/utils/storage.util.ts
+++ b/src/utils/storage.util.ts
@@ -1,6 +1,8 @@
-// chrome.storage.local 래퍼 유틸리티
+// chrome.storage 래퍼 유틸리티
 
 import type { StorageData, StorageKey } from '../types/storage.types';
+
+// ── chrome.storage.local ───────────────────────────────────
 
 /**
  * chrome.storage.local에서 단일 키 값을 조회
@@ -64,4 +66,33 @@ export function removeStorage(key: StorageKey): Promise<void> {
       resolve();
     });
   });
+}
+
+// ── chrome.storage.session ────────────────────────────────
+// 브라우저가 열려 있는 동안만 유지되는 세션 스토리지
+// 팝업을 닫았다 열어도 데이터가 유지됨 (브라우저 종료 시 초기화)
+
+/**
+ * chrome.storage.session에서 값을 조회
+ */
+export async function getSessionStorage<T>(key: string): Promise<T | undefined> {
+  const result = await chrome.storage.session.get(key);
+  return result[key] as T | undefined;
+}
+
+/**
+ * chrome.storage.session에 값을 저장
+ */
+export async function setSessionStorage(data: Record<string, unknown>): Promise<void> {
+  await chrome.storage.session.set(data);
+}
+
+/**
+ * chrome.storage.session에서 여러 키 값을 한 번에 조회
+ */
+export async function getSessionStorageMultiple<T extends Record<string, unknown>>(
+  keys: string[],
+): Promise<Partial<T>> {
+  const result = await chrome.storage.session.get(keys);
+  return result as Partial<T>;
 }


### PR DESCRIPTION
## Issue 
#31 

## Summary

댓글 목록 진입 후 다른 페이지로 이동하거나 팝업을 닫았다 열면 불러왔던 댓글이 초기화되던 문제를 해결

## Problem

**Case 1 — 설정 페이지 이동 후 복귀**
`router.navigate('/settings')` → 뒤로가기 시 `mountMainPage`가
재호출되면서 `loadComments`가 새로 실행되어 댓글이 초기화됨

**Case 2 — 팝업 닫았다 재진입**
Chrome이 팝업을 닫을 때 프로세스를 종료하므로
모듈 레벨 변수(`allComments`, `nextPageToken` 등)가 모두 초기화됨

## Solution

**Case 1**
`mountMainPage` 재호출 시 `prevVideoId`와 현재 `videoId`를 비교해
동일하고 `allComments`에 데이터가 있으면 API 재호출 없이 기존 상태를 렌더링

**Case 2**
`chrome.storage.session`을 활용해 댓글 상태를 세션에 캐싱
(브라우저가 열려있는 동안 유지, 브라우저 종료 시 자동 초기화)

## Changes

- `constants/index.ts` — `SESSION_KEY_*` 상수 4개 추가
- `utils/storage.util.ts` — `chrome.storage.session` 헬퍼 3개 추가
- `popup/pages/MainPage.ts`
  - 설정 페이지 복귀 시 동일 `videoId`면 기존 상태 복원
  - `loadComments` 완료 시 세션에 캐싱
  - 팝업 재진입 시 세션 캐시에서 상태 복원